### PR TITLE
Fix early exit

### DIFF
--- a/scenario_runner.py
+++ b/scenario_runner.py
@@ -132,7 +132,7 @@ class ScenarioRunner(object):
         """
         self._shutdown_requested = True
         if self.manager:
-            self.manager.stop_scenario()
+            self.manager._running = False
 
     def _get_scenario_class_or_fail(self, scenario):
         """
@@ -186,14 +186,6 @@ class ScenarioRunner(object):
         self.manager.cleanup()
 
         CarlaDataProvider.cleanup()
-
-        for i, _ in enumerate(self.ego_vehicles):
-            if self.ego_vehicles[i]:
-                if not self._args.waitForEgo and self.ego_vehicles[i] is not None and self.ego_vehicles[i].is_alive:
-                    print("Destroying ego vehicle {}".format(self.ego_vehicles[i].id))
-                    self.ego_vehicles[i].destroy()
-                self.ego_vehicles[i] = None
-        self.ego_vehicles = []
 
         if self.agent_instance:
             self.agent_instance.destroy()
@@ -415,7 +407,7 @@ class ScenarioRunner(object):
             self._analyze_scenario(config)
 
             # Remove all actors, stop the recorder and save all criterias (if needed)
-            scenario.remove_all_actors()
+            # scenario.remove_all_actors()
             if self._args.record:
                 self.client.stop_recorder()
                 self._record_criteria(self.manager.scenario.get_criteria(), recorder_name)

--- a/srunner/scenariomanager/scenario_manager.py
+++ b/srunner/scenariomanager/scenario_manager.py
@@ -182,7 +182,7 @@ class ScenarioManager(object):
                 sys.stdout.flush()
 
             if self.scenario_tree.status != py_trees.common.Status.RUNNING:
-                self._running = False
+                self._running = True
 
         if self._sync_mode and self._running and self._watchdog.get_status():
             CarlaDataProvider.get_world().tick()
@@ -198,7 +198,7 @@ class ScenarioManager(object):
         """
         This function is used by the overall signal handler to terminate the scenario execution
         """
-        self._running = False
+        pass
 
     def analyze_scenario(self, stdout, filename, junit, json):
         """


### PR DESCRIPTION
Seif made local changes to make ScenarioRunner work for FFI demo. The problem was that SR exited the openscenario early and then destroyed all actors. Now, SR will not shut down after finished scenario but instead wait for "ctrl+C" before cleaning up.